### PR TITLE
Get all proof

### DIFF
--- a/lib/oracle/oracle.js
+++ b/lib/oracle/oracle.js
@@ -35,7 +35,7 @@ class Oracle {
     return true;
   }
 
-  async submitAll(result, params) {
+  async getAllProof(result){
     let proofs = result.proofs;
     let proven = await this.getProven(result);
     let rrdata = [];
@@ -49,7 +49,12 @@ class Oracle {
       prevProof = '0x' + proofs[proven - 1].rrdata.toString('hex');
     }
     let data = '0x' + Buffer.concat(rrdata).toString('hex');
-    await this.contract.methods.submitRRSets(data, prevProof).send(params);
+    return [data, prevProof]
+  }
+
+  async submitAll(result, params) {
+    let data = await this.getAllProof(result);
+    await this.contract.methods.submitRRSets(...data).send(params);
   }
 
   async getProven(result) {

--- a/lib/oracle/oracle.js
+++ b/lib/oracle/oracle.js
@@ -35,7 +35,7 @@ class Oracle {
     return true;
   }
 
-  async getAllProof(result){
+  async getAllProofs(result){
     let proofs = result.proofs;
     let proven = await this.getProven(result);
     let rrdata = [];
@@ -53,7 +53,7 @@ class Oracle {
   }
 
   async submitAll(result, params) {
-    let data = await this.getAllProof(result);
+    let data = await this.getAllProofs(result);
     await this.contract.methods.submitRRSets(...data).send(params);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensdomains/dnsprovejs",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensdomains/dnsprovejs",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Port of dnsprove.go",
   "main": "dist/dnsprover.js",
   "scripts": {
@@ -16,7 +16,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@ensdomains/dnsregistrar": "0.0.1",
+    "@ensdomains/dnsregistrar": "0.0.3",
     "@ensdomains/dnssec-oracle": "0.0.5",
     "babel-polyfill": "^6.26.0",
     "dns-packet": "^5.0.0",


### PR DESCRIPTION
`getAllProof` returns all data needed to call `submitRRSets` so that dnsregistrar can use it to pass to `proveAndClaim` function.