### PR TITLE
Add end 2 end test for adding and deleting rrset

### DIFF
--- a/lib/dns/verifier.js
+++ b/lib/dns/verifier.js
@@ -138,6 +138,8 @@ async function verifyRRSet(sig, rrs) {
   }
   if (typeof sets != 'undefined') {
     return sets;
+  }else{
+    throw(`No matching keytag ${sig.data.keyTag} for signer ${sig.data.signersName} with algo ${sig.data.algorithm} and rrs header type ${rrsHeaderRtype}`)
   }
 }
 

--- a/lib/dns/verifier.js
+++ b/lib/dns/verifier.js
@@ -83,7 +83,7 @@ async function queryWithProof(qtype, name) {
   let ret, found;
 
   if(r.authorities.length > 0){
-    sigs = filterRRSIGWithTypeCovered(r.authorities, ['NSEC'])
+    sigs = filterRRSIGWithTypeCovered(r.authorities, ['NSEC', 'NSEC3'])
     rrs = filterRRs(r.authorities, ['NSEC', 'NSEC3']);
   }
   if(rrs.length == 0){
@@ -93,7 +93,6 @@ async function queryWithProof(qtype, name) {
       results: []
     }
   }
-
   for (const sig of sigs) {
     ret = await verifyRRSet(sig, rrs);
     if (ret) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensdomains/dnsprovejs",
-  "version": "0.0.7",
+  "version": "0.0.9",
   "description": "Port of dnsprove.go",
   "main": "dist/dnsprover.js",
   "scripts": {

--- a/test/integration.js
+++ b/test/integration.js
@@ -397,17 +397,15 @@ contract('DNSSEC', function(accounts) {
       assert.equal(dnsResult.found, true);
       assert.equal(dnsResult.results[1].rrs[0].data.toString().split('=')[1], owner);
       let proofs = dnsResult.proofs
-      // adding anchor;
-      await oracle.submitProof(proofs[0], null, { from: owner, gas:gas });
-      // adding proof
-      await oracle.submitProof(proofs[1], proofs[0], { from: owner, gas:gas });
+      // adding proofs;
+      await oracle.submitAll(dnsResult, { from: owner, gas:gas });
       let result = await oracle.knownProof(dnsResult.proofs[1]);
       assert.notEqual(parseInt(result), 0);
       const dnsResult2 = await dnsprove.lookup('TXT', 'b');
       assert.equal(dnsResult2.found, false);
       assert.equal(dnsResult2.nsec, true);
       let nsecproofs = dnsResult2.proofs
-      await oracle.deleteProof('TXT', 'b', nsecproofs[1], proofs[0], {from:owner, gas:gas})
+      await oracle.deleteProof('TXT', 'b', nsecproofs[1], nsecproofs[0], {from:owner, gas:gas})
       result = await oracle.knownProof(dnsResult.proofs[1]);
       assert.equal(parseInt(result), 0);
     })

--- a/test/integration.js
+++ b/test/integration.js
@@ -136,7 +136,7 @@ contract('DNSSEC', function(accounts) {
                             rrtypes:["TXT"]
                          }
                       },
-                      { name: '_ans.matoken.xyz', type: 'RRSIG',  class: 'IN', data: rrsigdata('NSEC', 'matoken.xyz', { labels:3, keyTag:5647 }) }
+                      { name: '_ans.matoken.xyz', type: 'RRSIG',  class: 'IN', data: rrsigdata('NSEC', 'matoken.xyz', { labels:3, keyTag:1277 }) }
                    ]
                   }));
 
@@ -146,7 +146,7 @@ contract('DNSSEC', function(accounts) {
                     questions: [ { name: '_ens.matoken.xyz', type: 'TXT', class: 'IN' } ],
                     answers: [
                       { name: '_ens.matoken.xyz', type: 'TXT', class: 'IN',  data: text },
-                      { name: '_ens.matoken.xyz', type: 'RRSIG',class: 'IN', data: rrsigdata('TXT', 'matoken.xyz', {labels:3}) }
+                      { name: '_ens.matoken.xyz', type: 'RRSIG',class: 'IN', data: rrsigdata('TXT', 'matoken.xyz', {labels:3, keyTag:5647}) }
                     ]
                   }));
   
@@ -180,7 +180,7 @@ contract('DNSSEC', function(accounts) {
                     answers: [
                       { name: 'xyz', type: 'DNSKEY', class: 'IN', data: dnskeydata },
                       { name: 'xyz', type: 'DNSKEY', class: 'IN', data: dnskeydata2 },
-                      { name: 'xyz', type: 'RRSIG',  class: 'IN', data: rrsigdata('DNSKEY', 'xyz') }
+                      { name: 'xyz', type: 'RRSIG',  class: 'IN', data: rrsigdata('DNSKEY', 'xyz', {labels:1}) }
                     ]
                   }));
   
@@ -190,7 +190,7 @@ contract('DNSSEC', function(accounts) {
                   .reply(200, packet.encode({
                     questions: [ { name: 'xyz', type: 'DS', class: 'IN' } ],
                     answers: [
-                      { name: 'xyz', type: 'RRSIG',  class: 'IN', data: rrsigdata('DS', '.') },
+                      { name: 'xyz', type: 'RRSIG',  class: 'IN', data: rrsigdata('DS', '.', {labels:1, keyTag:5647}) },
                       { name: 'xyz', type: 'DS', class: 'IN', data: dsdata }
                     ]
                   }));
@@ -201,8 +201,7 @@ contract('DNSSEC', function(accounts) {
                   .reply(200, packet.encode({
                     questions: [ { name: '.', type: 'DNSKEY', class: 'IN' } ],
                     answers: [
-                      { name: '.', type: 'DNSKEY', class: 'IN', data: dnskeydata },
-                      { name: '.', type: 'DNSKEY', class: 'IN', data: {flags: 257, algorithm: 253, key: new Buffer([17, 17])} },
+                      { name: '.', type: 'DNSKEY', class: 'IN', data: {flags: 0x0101, algorithm: 253, key: Buffer.from("1111", "HEX")} },
                       { name: '.', type: 'RRSIG',  class: 'IN', data: rrsigdata('DNSKEY', '.', { labels:0, keyTag:5647 }) }
                     ]
                   }));
@@ -306,8 +305,8 @@ contract('DNSSEC', function(accounts) {
                   questions: [ { name: '.', type: 'DNSKEY', class: 'IN' } ],
                   answers: [
                     { name: '.', type: 'DNSKEY', class: 'IN', data: {flags: 0x0101, algorithm: 253, key: Buffer.from("1111", "HEX")} },
-                    { name: '.', type: 'DNSKEY', class: 'IN', data: {flags: 0, algorithm: 253, key: Buffer.from("1111", "HEX")} },
-                    { name: '.', type: 'DNSKEY', class: 'IN', data: {flags: 0, algorithm: 253, key: Buffer.from("1112", "HEX")} },
+                    { name: '.', type: 'DNSKEY', class: 'IN', data: {flags: 257, algorithm: 253, key: Buffer.from("1111", "HEX")} },
+                    { name: '.', type: 'DNSKEY', class: 'IN', data: {flags: 257, algorithm: 253, key: Buffer.from("1112", "HEX")} },
                     { name: '.', type: 'RRSIG',  class: 'IN', data: rrsigdata('DNSKEY', '.', { labels:0, keyTag:5647 }) }
                   ]
                 }));
@@ -387,8 +386,8 @@ contract('DNSSEC', function(accounts) {
                   questions: [ { name: '.', type: 'DNSKEY', class: 'IN' } ],
                   answers: [
                     { name: '.', type: 'DNSKEY', class: 'IN', data: {flags: 0x0101, algorithm: 253, key: Buffer.from("1111", "HEX")} },
-                    { name: '.', type: 'DNSKEY', class: 'IN', data: {flags: 0, algorithm: 253, key: Buffer.from("1111", "HEX")} },
-                    { name: '.', type: 'DNSKEY', class: 'IN', data: {flags: 0, algorithm: 253, key: Buffer.from("1112", "HEX")} },
+                    { name: '.', type: 'DNSKEY', class: 'IN', data: {flags: 257, algorithm: 253, key: Buffer.from("1111", "HEX")} },
+                    { name: '.', type: 'DNSKEY', class: 'IN', data: {flags: 257, algorithm: 253, key: Buffer.from("1112", "HEX")} },
                     { name: '.', type: 'RRSIG',  class: 'IN', data: rrsigdata('DNSKEY', '.', { labels:0, keyTag:5647 }) }
                   ]
                 }));


### PR DESCRIPTION

- Support NSEC3
- Add test to delete entry from dnssec oracale and ens
- Throw more meaningful error when keytag does not match.
- Bump up version