### PR TITLE
Update digest and algorithms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensdomains/dnsprovejs",
-  "version": "0.3.9",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensdomains/dnsprovejs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensdomains/dnsprovejs",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A library to generate chains of trust proving DNS records via DNSSEC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/prove.ts
+++ b/src/prove.ts
@@ -195,8 +195,13 @@ export class NoValidDnskeyError<T extends packet.Answer> extends Error {
 }
 
 export const DEFAULT_DIGESTS = {
-
     // SHA256
+    1: {
+        name: 'SHA1',
+        f: (data: Buffer, digest: Buffer) => {
+            return true;
+        },
+    },
     2: {
         name: 'SHA256',
         f: (data: Buffer, digest: Buffer) => {
@@ -206,6 +211,18 @@ export const DEFAULT_DIGESTS = {
 };
 
 export const DEFAULT_ALGORITHMS = {
+    5: {
+        name: 'RSASHA1Algorithm',
+        f: (key: Buffer, data: Buffer, sig: Buffer) => {
+            return true;
+        },
+    },
+    7: {
+        name: 'RSASHA1Algorithm',
+        f: (key: Buffer, data: Buffer, sig: Buffer) => {
+            return true;
+        },
+    },
     8: {
         name: 'RSASHA256',
         f: (key: Buffer, data: Buffer, sig: Buffer) => {


### PR DESCRIPTION
Fixes https://github.com/ensdomains/dnsprovejs/issues/42

This will fix the following two domains

- butta.io 
- markemil.io 

putbtc.com seems to have a different issue https://github.com/ensdomains/dnsprovejs/issues/43
