### PR TITLE
Add support of Google public DNS resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ensdomains/dnsprovejs",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A library to generate chains of trust proving DNS records via DNSSEC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/prove.ts
+++ b/src/prove.ts
@@ -92,8 +92,8 @@ export function dohQuery(url: string) {
     const buf = packet.encode(q)
     const response = await fetch(
       `${url}?${encodeURLParams({
-        ct: 'application/dns-udpwireformat',
-        dns: buf.toString('base64'),
+        ct: 'application/dns-message',
+        dns: buf.toString('base64url'),
         ts: Date.now().toString(),
       })}`,
     )

--- a/tests/real_records.test.ts
+++ b/tests/real_records.test.ts
@@ -98,4 +98,24 @@ describe('dnsprovejs', () => {
     })
     expect(result.proofs.length).toEqual(5)
   })
+
+  it('queries TXT from cloudflare doh correctly', async () => {
+    const prover = DNSProver.create('https://cloudflare-dns.com/dns-query');
+    const result = await prover.queryWithProof('TXT', '_ens.proofofattendance.com')
+    checkKeyTags(result)
+    expect(result.answer).toMatchObject({
+      records: [{ name: '_ens.proofofattendance.com', type: 'TXT' }],
+      signature: { name: '_ens.proofofattendance.com' },
+    })
+  });
+
+  it('queries TXT from google doh correctly', async () => {
+    const prover = DNSProver.create('https://dns.google/dns-query');
+    const result = await prover.queryWithProof('TXT', '_ens.proofofattendance.com')
+    checkKeyTags(result)
+    expect(result.answer).toMatchObject({
+      records: [{ name: '_ens.proofofattendance.com', type: 'TXT' }],
+      signature: { name: '_ens.proofofattendance.com' },
+    })
+  })
 })


### PR DESCRIPTION
Current version of Google DNS DOH resolver requires usage of url-safe base64 encoding and modern `application/dns-message` header. Cloudflare DOH supports them as well so I don't expect any breaking changes there. I've added two tests with real networking to ensure that library still supports Cloudflare DOH resolver as well as Google's one. 