### PR TITLE
feat: Add new IANA Trust Anchor

### DIFF
--- a/src/prove.ts
+++ b/src/prove.ts
@@ -32,6 +32,21 @@ export const DEFAULT_TRUST_ANCHORS: packet.Ds[] = [
       ),
     },
   },
+  {
+    name: '.',
+    type: 'DS',
+    class: 'IN',
+    data: {
+      keyTag: 38696,
+      algorithm: 8,
+      digestType: 2,
+      digest: Buffer.from(
+        '683D2D0ACB8C9B712A1948B27F741219298D0A450D612C483AF444A4C0FB2B16',
+        'hex',
+      ),
+    },
+  },
+  
 ]
 
 function encodeURLParams(p: { [key: string]: string }): string {


### PR DESCRIPTION
A new TA is available and is expected to start signing in 2026:
https://data.iana.org/root-anchors/root-anchors.xml